### PR TITLE
Add deps that are used and remove ones that aren't

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -1,19 +1,20 @@
 { name = "argparse-basic"
 , dependencies =
   [ "arrays"
-  , "console"
-  , "debug"
-  , "effect"
+  , "bifunctors"
+  , "control"
   , "either"
   , "foldable-traversable"
-  , "free"
+  , "integers"
   , "lists"
   , "maybe"
-  , "node-process"
-  , "psci-support"
+  , "newtype"
+  , "numbers"
+  , "prelude"
   , "record"
   , "strings"
-  , "transformers"
+  , "tuples"
+  , "unfoldable"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]


### PR DESCRIPTION
`spago build` fails on `main` because the code uses modules from dependencies not in `spago.dhall`, so I installed those in this PR. I also took the opportunity to remove unused dependencies, which Spago also warns about.