### PR TITLE
Update for PureScript 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,10 @@ jobs:
       - name: Build source
         run: spago build
 
+      - name: Verify Bower
+        run: |
+          npx bower install
+          npx pulp build
+
       - name: Verify formatting
         run: purs-tidy check src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: purescript-contrib/setup-purescript@main
+        with:
+          purescript: "0.15.0"
+          purs-tidy: "0.8.0"
+          spago: "0.20.8"
+
+      - name: Build source
+        run: spago build
+
+      - name: Verify formatting
+        run: purs-tidy check src

--- a/.tidyrc.json
+++ b/.tidyrc.json
@@ -1,0 +1,10 @@
+{
+  "importSort": "ide",
+  "importWrap": "source",
+  "indent": 2,
+  "operatorsFile": null,
+  "ribbon": 1,
+  "typeArrowPlacement": "first",
+  "unicode": "never",
+  "width": null
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,26 @@
+{
+  "name": "purescript-argparse-basic",
+  "license": ["MIT"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/natefaubion/purescript-argparse-basic.git"
+  },
+  "ignore": ["**/.*", "node_modules", "bower_components", "output"],
+  "dependencies": {
+    "purescript-arrays": "^v7.0.0",
+    "purescript-bifunctors": "^v6.0.0",
+    "purescript-control": "^v6.0.0",
+    "purescript-either": "^v6.0.0",
+    "purescript-foldable-traversable": "^v6.0.0",
+    "purescript-integers": "^v6.0.0",
+    "purescript-lists": "^v7.0.0",
+    "purescript-maybe": "^v6.0.0",
+    "purescript-newtype": "^v5.0.0",
+    "purescript-numbers": "^v9.0.0",
+    "purescript-prelude": "^v6.0.0",
+    "purescript-record": "^v4.0.0",
+    "purescript-strings": "^v6.0.0",
+    "purescript-tuples": "^v7.0.0",
+    "purescript-unfoldable": "^v6.0.0"
+  }
+}

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,4 +1,5 @@
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210324/packages.dhall sha256:b4564d575da6aed1c042ca7936da97c8b7a29473b63f4515f09bb95fae8dddab
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.0-20220502/packages.dhall
+        sha256:38d347aeba9fe6359c208abe87a5cecf1ffb14294f11ad19664ae35c59b6e29a
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,4 +1,6 @@
 { name = "argparse-basic"
+, license = "MIT"
+, repository = "https://github.com/natefaubion/purescript-argparse-basic.git"
 , dependencies =
   [ "arrays"
   , "bifunctors"

--- a/spago.dhall
+++ b/spago.dhall
@@ -17,5 +17,5 @@
   , "unfoldable"
   ]
 , packages = ./packages.dhall
-, sources = [ "src/**/*.purs", "test/**/*.purs" ]
+, sources = [ "src/**/*.purs" ]
 }


### PR DESCRIPTION
This PR updates the library for PureScript 0.15 by upgrading the package set. It also:

1. Adds continuous integration that builds the project both with Spago + package sets and Pulp + Bower so both sets of dependencies are verified.
2. Adds a bower.json file generated with `spago bump-version patch --no-dry-run`, which can be regenerated when dependencies change in the future. This is necessary for Pursuit publishing.
3. Adds a `.tidyrc.json` file for formatting code contributed to the library. This is also checked in CI.